### PR TITLE
fix compatibility with django_cms 3.1

### DIFF
--- a/image_gallery/admin.py
+++ b/image_gallery/admin.py
@@ -1,13 +1,13 @@
 """Simple admin registration for ``image_gallery`` models."""
 from django.contrib import admin
 
-from cms.admin.placeholderadmin import PlaceholderAdmin
+from cms.admin.placeholderadmin import PlaceholderAdminMixin
 from filer.admin.imageadmin import ImageAdmin
 
 from . import models
 
 
-class GalleryAdmin(PlaceholderAdmin):
+class GalleryAdmin(PlaceholderAdminMixin, admin.ModelAdmin):
     """Custom admin for the ``Gallery`` model."""
     list_display = ('title', 'date', 'location', 'folder', 'category')
     list_filter = ['category', ]


### PR DESCRIPTION
PlaceholderAdmin was deprecated some time ago In 3.1 it was removed.
This fixes following Exception:
    from cms.admin.placeholderadmin import PlaceholderAdmin
ImportError: cannot import name PlaceholderAdmin