### PR TITLE
Fixed broken migration (failed with Value error)

### DIFF
--- a/image_gallery/migrations/0001_initial.py
+++ b/image_gallery/migrations/0001_initial.py
@@ -10,7 +10,7 @@ import cms.models.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '__first__'),
+        ('cms', '0003_auto_20140926_2347'),
         ('filer', '__first__'),
     ]
 


### PR DESCRIPTION
Running 'python manage.py migrate' failed with a Value Error. The solution is to make the plugins migration depend on a later migration of django cms. cms.Placeholder had been changed with migration 003.